### PR TITLE
Make program installable with python 3.8

### DIFF
--- a/pywaybackup/Verbosity.py
+++ b/pywaybackup/Verbosity.py
@@ -1,4 +1,6 @@
 from tqdm import tqdm
+from typing import Union 
+
 
 
 class Verbosity:
@@ -28,7 +30,7 @@ class Verbosity:
             cls.log.close()
 
     @classmethod
-    def write(cls, verbose: bool = None, content: str | list = None):
+    def write(cls, verbose: bool = None, content: Union[str, list] = None):
         """
         Writes log entries to stdout or logfile based on verbosity level and progress-bar status.
 


### PR DESCRIPTION
So, just trying to get this working on my local setup. 

I see that the main branch and the version available through pip is in python3.8. I tried building dev branch with 3.8 but it failed with the following stack trace, this PR makes it run on 3.8: 

Ps. haven't done that much python programming (working in a java world), so sorry if I've misunderstood anything.

```
Traceback (most recent call last):
  File "C:\Users\user\AppData\Local\Programs\Python\Python38\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\user\AppData\Local\Programs\Python\Python38\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\user\code\python-wayback-machine-downloader\.venv\Scripts\waybackup.exe\__main__.py", line 4, in <module>
  File "c:\users\user\code\python-wayback-machine-downloader\.venv\lib\site-packages\pywaybackup\main.py", line 4, in <module>
    import pywaybackup.archive_download as archive_download
  File "c:\users\user\code\python-wayback-machine-downloader\.venv\lib\site-packages\pywaybackup\archive_download.py", line 19, in <module>
    from pywaybackup.SnapshotCollection import SnapshotCollection as sc
  File "c:\users\user\code\python-wayback-machine-downloader\.venv\lib\site-packages\pywaybackup\SnapshotCollection.py", line 7, in <module>
    from pywaybackup.Verbosity import Verbosity as vb
  File "c:\users\user\code\python-wayback-machine-downloader\.venv\lib\site-packages\pywaybackup\Verbosity.py", line 4, in <module>
    class Verbosity:
  File "c:\users\user\code\python-wayback-machine-downloader\.venv\lib\site-packages\pywaybackup\Verbosity.py", line 31, in Verbosity
    def write(cls, verbose: bool = None, content: str | list = None):
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```
