### PR TITLE
Add more limiting options to python-wayback-machine-downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+copilot-instructions.md
 
 # Spyder project settings
 .spyderproject
@@ -167,3 +168,5 @@ cython_debug/
 
 # custom
 test.py
+waybackup_snapshots/
+output/

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ Parameters for archive.org CDX query. No effect on snapshot download itself.
 - **`--limit`** `<count>`:<br>
   Limits the snapshots fetched from archive.org CDX. (Will have no effect on existing CDX files)
 
+- **`--max-snapshots-per-url`** `<count>`:<br>
+  Limits the number of snapshots kept per unique URL after CDX insertion and filtering. Selection is distributed across the requested date range so retained snapshots represent the whole timespan. Useful to cap harvest depth for large sites. Example: `--limit 10000 --max-snapshots-per-url 100` queries up to 10k snapshots then keeps up to 100 per unique URL.
+
+- **`--path-depth`** `<N>`:<br>
+  Limit harvested URLs by path depth. `0` = only `example.com/` (root), `1` = root + immediate children (e.g. `example.com/foo/`), `2` = two levels, etc. Applied after CDX insertion and mode filtering. Combine with `--max-snapshots-per-url` to cap snapshots per kept URL.
+
 - **Range Selection:**<br>
   Set the query range in years (`range`) or a timestamp (`start` and/or `end`). If `range` then ignores `start` and `end`. Format for timestamps: YYYYMMDDhhmmss. Timestamp can as specific as needed (year 2019, year+month+day 20190101, ...).
 

--- a/pywaybackup/Arguments.py
+++ b/pywaybackup/Arguments.py
@@ -40,6 +40,18 @@ class Arguments:
         behavior.add_argument("--retry", type=int, default=0, metavar="", help="retry failed downloads (opt tries as int, else infinite)")
         behavior.add_argument("--workers", type=int, default=1, metavar="", help="number of workers (simultaneous downloads)")
         behavior.add_argument("--delay", type=int, default=0, metavar="", help="delay between each download in seconds")
+        behavior.add_argument(
+            "--max-snapshots-per-url",
+            type=int,
+            metavar="",
+            help="limit number of snapshots to keep per unique URL (distributed across date range)",
+        )
+        behavior.add_argument(
+            "--path-depth",
+            type=int,
+            metavar="",
+            help="limit harvested URLs by path depth: 0=root only, 1=include immediate children, etc.",
+        )
 
         special = parser.add_argument_group("special")
         special.add_argument("--reset", action="store_true", help="reset the job and ignore existing cdx/db/csv files")

--- a/pywaybackup/PyWayBackup.py
+++ b/pywaybackup/PyWayBackup.py
@@ -133,6 +133,8 @@ class PyWayBackup:
         keep: bool = False,
         silent: bool = True,
         debug: bool = False,
+        max_snapshots_per_url: int = None,
+        path_depth: int = None,
         **kwargs: dict,
     ):
         self._url = url
@@ -158,6 +160,8 @@ class PyWayBackup:
         self._delay = delay
         self._reset = reset
         self._keep = keep
+        self._max_snapshots_per_url = max_snapshots_per_url
+        self._path_depth = path_depth
 
         # module exclusive
         self._silent = silent
@@ -184,6 +188,8 @@ class PyWayBackup:
             + str(self._start)
             + str(self._end)
             + str(self._limit)
+            + str(self._max_snapshots_per_url)
+            + str(self._path_depth)
             + str(self._filetype)
             + str(self._statuscode)
         )
@@ -324,7 +330,13 @@ class PyWayBackup:
             SnapshotCollection: The initialized and loaded snapshot collection.
         """
         collection = SnapshotCollection()
-        collection.load(mode=self._mode, cdxfile=self._cdxfile, csvfile=self._csvfile)
+        collection.load(
+            mode=self._mode,
+            cdxfile=self._cdxfile,
+            csvfile=self._csvfile,
+            max_snapshots_per_url=self._max_snapshots_per_url,
+            path_depth=self._path_depth,
+        )
         collection.print_calculation()
         return collection
 


### PR DESCRIPTION
This is my first crude attempt (hence draft PR) at this and the work done includes:

- Adds CLI flags `--path-depth` and `--max-snapshots-per-url`.
- Implements DB-side filtering to prune snapshots by URL path depth and cap snapshots per unique URL.
- Parses snapshot timestamps from `waybackup_snapshots/<site>/<YYYYMMDDhhmmss>/` folder names for improved temporal analysis.

Files touched
- `pywaybackup/Arguments.py` — new CLI flag
- `pywaybackup/PyWayBackup.py` — pass flag through job args
- `pywaybackup/SnapshotCollection.py` — filtering and parsing logic
- `README.md` — docs for new flags

Notes
- Default behavior is unchanged when flags are omitted.

Helper script to test and compare the harvests `harvest_comparator.py` is available at: https://github.com/WEB-CHILD/Scripts

Disclaimer: I still want to test this some more and that will require some structured harvesting. So this draft PR is so we can discuss if this is heading in the right direction. 


