### PR TITLE
feat: PyInstaller builds for Windows, Linux, and macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,65 @@
+name: Build executables
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            suffix: linux
+            ext: ""
+          - os: windows-latest
+            suffix: windows
+            ext: ".exe"
+          - os: macos-latest
+            suffix: macos
+            ext: ""
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install . pyinstaller
+
+      - name: Build executable
+        run: pyinstaller --onefile --name waybackup --additional-hooks-dir=hooks pywaybackup/main.py
+
+      - name: Rename artifact
+        shell: bash
+        run: mv "dist/waybackup${{ matrix.ext }}" "dist/waybackup-${{ matrix.suffix }}${{ matrix.ext }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: waybackup-${{ matrix.suffix }}
+          path: dist/waybackup-${{ matrix.suffix }}${{ matrix.ext }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
 name: Build executables
 
 on:
-  push:
-    tags:
-      - "v*"
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -48,7 +46,6 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
     steps:
@@ -58,8 +55,7 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Create GitHub Release
+      - name: Attach binaries to release
         uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*
-          generate_release_notes: true

--- a/hooks/hook-magic.py
+++ b/hooks/hook-magic.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+
+datas = collect_data_files("magic")
+binaries = collect_dynamic_libs("magic")


### PR DESCRIPTION
## Summary
- Adds a PyInstaller hook (`hooks/hook-magic.py`) to bundle `python-magic-standalone`'s shared libraries and data files into the executable
- Adds a GitHub Actions workflow (`.github/workflows/build.yml`) that builds Linux, Windows, and macOS executables on tag push or manual dispatch
- On tag push, automatically creates a GitHub Release with all three platform binaries attached (with auto-generated release notes)

## Test plan
- [x] Triggered workflow manually on fork — all 3 platform builds succeeded: https://github.com/HN-Tran/python-wayback-machine-downloader/actions/runs/23326178541
- [x] Linux executable tested locally: `-h` and actual download both work
- [ ] Test Windows and macOS executables
- [ ] Push a test tag to verify GitHub Release creation