### PR TITLE
Dispose SQLAlchemy engine before deleting .db file (fixes #57)

### DIFF
--- a/pywaybackup/PyWayBackup.py
+++ b/pywaybackup/PyWayBackup.py
@@ -510,6 +510,7 @@ class PyWayBackup:
         collection = SnapshotCollection()
         collection.close()
         self._csvfile.store_result()
+        db.close_engine()
         self._f_keep()
         vb.fini()
         signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/pywaybackup/db.py
+++ b/pywaybackup/db.py
@@ -95,6 +95,7 @@ class Database:
     dbfile = None
     query_identifier = None
     query_exist = False
+    engine = None
     sessman = sessionmaker()
     query_progress = "0 / 0"
 
@@ -109,9 +110,9 @@ class Database:
         """
         cls.dbfile = dbfile
         cls.query_identifier = query_identifier
-        engine = create_engine(f"sqlite:///{dbfile}")
-        cls.sessman = sessionmaker(bind=engine)
-        Base.metadata.create_all(engine)
+        cls.engine = create_engine(f"sqlite:///{dbfile}")
+        cls.sessman = sessionmaker(bind=cls.engine)
+        Base.metadata.create_all(cls.engine)
 
         db = Database()
         if db.session.execute(
@@ -122,6 +123,19 @@ class Database:
         else:
             db.session.execute(insert(waybackup_job).values(query_identifier=query_identifier))
         db.close()
+
+    @classmethod
+    def close_engine(cls):
+        """
+        Dispose of the SQLAlchemy engine and release SQLite file handles.
+
+        Required on Windows before the .db file can be deleted, since the OS
+        holds an exclusive lock on open files. No-op on platforms where this
+        isn't required, and idempotent if called more than once.
+        """
+        if cls.engine is not None:
+            cls.engine.dispose()
+            cls.engine = None
 
     def __init__(self):
         """


### PR DESCRIPTION
Fixes #57

## What this changes

`Database.init()` previously created the SQLAlchemy engine as a local variable and bound it through `sessionmaker`, but the engine itself was never explicitly disposed. On Windows that causes `_f_keep()` to crash with `PermissionError: [WinError 32]` when it tries to `os.remove()` the `.db` file at shutdown — the OS refuses to delete a file that still has open handles.

This PR:

1. Stores the engine on the `Database` class (`cls.engine`) so it can be reached after `init`.
2. Adds a `Database.close_engine()` classmethod that disposes the engine and clears the reference. Idempotent and harmless on platforms where it isn't needed.
3. Calls `db.close_engine()` from `PyWayBackup._shutdown()`, between `_csvfile.store_result()` and `_f_keep()`, so the SQLite file handle is released before the delete is attempted.

Diff is small — 18 insertions, 3 deletions, two files.

## Verification

Reproduction case from #57 (Windows 11, Python 3.13.13, multi-worker run with `--keep` off):

| | Before | After |
|---|---|---|
| Exit code | 139 (segfault on shutdown) | 0 |
| `.db` file after run | left on disk | cleaned up |
| Traceback in error log | `PermissionError [WinError 32]` | none |

Tested with `waybackup -u https://couchtourist.com -l --limit 30 --reset --workers 5 -o <tempdir>`. Cleanup ran cleanly and the `.db` and `.cdx` files were both removed as `_f_keep()` intends.

No behaviour change on Linux/macOS — `engine.dispose()` is safe and standard there too, just unnecessary for the file-deletion case.